### PR TITLE
team: workaround to wait 2 secs for active-port

### DIFF
--- a/features/step_definitions/wicked_tests.rb
+++ b/features/step_definitions/wicked_tests.rb
@@ -982,6 +982,7 @@ end
 
 Then /^([^ ]*) should be the active link$/ do |interface|
   SUT.test_and_drop_results "log.sh step \"Then #{interface} should be the active link\""
+  sleep 2
   out, local, remote, command = SUT.test_and_store_results_together \
     "teamdctl team0 state view"
   local.should == 0; remote.should == 0; command.should == 0


### PR DESCRIPTION
teamd currently seems to just report UP causing wicked
to report success and start to verify the ports after
where it needs a second for.
