### PR TITLE
do not expect broadcast when config did not set any

### DIFF
--- a/features/step_definitions/wicked_tests.rb
+++ b/features/step_definitions/wicked_tests.rb
@@ -405,9 +405,9 @@ Then /^the scripts output should be as expected$/ do
   local.should == 0; remote.should == 0; command.should == 0
   out.should match /^pre-up eth0
 post-up eth0
-    inet #{DHCP4_SUT0}.* brd #{DHCP4_SUT0}.* scope global eth0
+    inet #{DHCP4_SUT0}.* scope global eth0
 pre-down eth0
-    inet #{DHCP4_SUT0}.* brd #{DHCP4_SUT0}.* scope global eth0
+    inet #{DHCP4_SUT0}.* scope global eth0
 post-down eth0$/
 end
 


### PR DESCRIPTION
wicked has been cleaned up to not preform pointless broadcast
calculations and set broadcast when config (dhcp) requests it
only -- like with ip address utility:
  ip addr add $addr brd $brd dev $dev -> brd is sent to kernel
  ip addr add $addr dev $dev -> brd is not sent to kernel
