### PR TITLE
ovs: revert xml config change in commit b17185a

### DIFF
--- a/test-files/ovs-bridge/ovs-bridge.xml
+++ b/test-files/ovs-bridge/ovs-bridge.xml
@@ -26,6 +26,13 @@
 </interface>
 
 <interface>
+  <name>ovs-system</name>
+  <control>
+    <mode>hotplug</mode>
+  </control>
+</interface>
+
+<interface>
   <name>eth1</name>
 
   <link>


### PR DESCRIPTION
An _ifcfg-ovs-system_ is not needed any more because
the xml config is generated from ifcfg-ovsbrX ...
