### PR TITLE
do not enforce rpm availability in osc build mode

### DIFF
--- a/jenkins-files/config-job.template
+++ b/jenkins-files/config-job.template
@@ -66,7 +66,7 @@ to use for the system under tests</description>
         <hudson.model.StringParameterDefinition>
           <name>BS_PKG</name>
           <description>the package name in the build system (always wicked in git mode)</description>
-          <defaultValue>wicked</defaultValue>
+          <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>BS_PROJ</name>


### PR DESCRIPTION
when git build is disabled to use osc fetch mode and there is no
specific project/package/repo/arch given, we try to fetch it via
osc getbinaries from default project, but on "no binaries found"
we test (last released wicked) RPMs provided by the sut image.
