### PR TITLE
config-job: fix distribution and auto-disable

### DIFF
--- a/jenkins-files/config-job.sh
+++ b/jenkins-files/config-job.sh
@@ -1,50 +1,65 @@
 #! /bin/bash
 
+ID=0
 SUBDIR="cucumber"
 GIT_REPO="openSUSE"
 JOBS_DIR=/var/lib/jenkins/jobs
+# do not auto-enable all jobs;
+# better to auto-disable them
+# when this script gets called
+# [on install or on update].
+DISABLED="true"
 
 function configure()
 {
+  printf "ID=%02u\t%-24s\t%-24s\t%s\t%s\n" "$ID" "$NAME" "$DISTRIBUTION" "$GIT_REPO" "$BRANCH_NAME"
   test -d "$JOBS_DIR/$NAME" || mkdir -p "$JOBS_DIR/$NAME" || exit 1
   sed "s!@@SUBDIR@@!$SUBDIR!g;
        s!@@GIT_REPO@@!$GIT_REPO!g;
+       s!@@DISTRIBUTION@@!$DISTRIBUTION!g;
+       s!@@DISABLED@@!$DISABLED!g;
        s!@@BRANCH_NAME@@!$BRANCH_NAME!g;
        s!@@ID@@!$ID!g;
        s!@@NANNY@@!$NANNY!g" \
       config-job.template > "$JOBS_DIR/$NAME/config.xml"
 }
 
+DISTRIBUTION="SLES 12 SP1 (x86_64)"
 BRANCH_NAME="master"
 NANNY="without"
 NAME=wicked-master
 ID=1
 configure
 
+DISTRIBUTION="SLES 12 SP1 (x86_64)"
 BRANCH_NAME="master"
 NANNY="with"
 NAME=wicked-master-nanny
 ID=2
 configure
 
+DISTRIBUTION="SLES 12 SP1 (x86_64)"
 BRANCH_NAME="testing"
 NANNY="without"
 NAME=wicked-testing
 ID=3
 configure
 
+DISTRIBUTION="SLES 12 SP1 (x86_64)"
 BRANCH_NAME="testing"
 NANNY="with"
 NAME=wicked-testing-nanny
 ID=4
 configure
 
+DISTRIBUTION="SLES 12 SP0 (x86_64)"
 BRANCH_NAME="sle12"
 NANNY="without"
 NAME=wicked-sle12
 ID=5
 configure
 
+DISTRIBUTION="SLES 12 SP0 (x86_64)"
 BRANCH_NAME="sle12"
 NANNY="with"
 NAME=wicked-sle12-nanny

--- a/jenkins-files/config-job.template
+++ b/jenkins-files/config-job.template
@@ -20,6 +20,7 @@ Github &quot;@@BRANCH_NAME@@&quot; branch, @@NANNY@@ nanny</description>
 to use for the system under tests</description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
+              <string></string>
               <string>SLES 12 SP1 (x86_64)</string>
               <string>SLES 12 SP0 (x86_64)</string>
               <string>openSUSE 13.2 (x86_64)</string>
@@ -103,7 +104,7 @@ to use for the system under tests</description>
     <extensions/>
   </scm>
   <canRoam>true</canRoam>
-  <disabled>false</disabled>
+  <disabled>@@DISABLED@@</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
@@ -118,6 +119,8 @@ to use for the system under tests</description>
       <command>
 export NANNY=&quot;@@NANNY@@&quot;
 export SUBDIR=&quot;@@SUBDIR@@&quot;
+export DISTRIBUTION=&quot;${DISTRIBUTION:-@@DISTRIBUTION@@}&quot;
+
 # Please use a unique identifier below:
 export ID=&quot;@@ID@@&quot;
 


### PR DESCRIPTION
Pre-define distribution default for each job, so sle12
branch is not tested agains SLE-12 and not SLE-12-SP1.

It is better to disable jobs when config gets recreated
than to enable jobs, which are disabled for some reason
as the script is called at installation/migration time.
